### PR TITLE
metrodr-script:  enhancement

### DIFF
--- a/hack/metrodr-script.sh
+++ b/hack/metrodr-script.sh
@@ -202,7 +202,6 @@ then
 
 	echo "======Patching default storageClass to rbd"
         kubectl --context "${CEPHCLUSTER}" patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-        kubectl --context "${CEPHCLUSTER}" patch storageclass rook-cephfs -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
         kubectl --context "${CEPHCLUSTER}" patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
         kubectl --context "${CEPHCLUSTER}" get storageclass 
         # install ramen

--- a/hack/metrodr-script.sh
+++ b/hack/metrodr-script.sh
@@ -131,7 +131,7 @@ then
 	echo "storage cluster:" && echo "$CEPHCLUSTER"
 	echo "network:" && echo "$METRONET"
 	
-	metroNetIP=$(virsh net-dumpxml "$(virsh net-list --name | grep "${METRONET}")" | grep "ip address" | cut -d"=" -f2 | cut -d" " -f1 | tr -d "'")
+	metroNetIP=$(virsh net-dumpxml "${METRONET}" | grep "ip address" | cut -d"=" -f2 | cut -d" " -f1 | tr -d "'")
         minikube start --profile "${HUBCLUSTER}" --network="${METRONET}" --insecure-registry="${metroNetIP}/24" --nodes=1 --extra-disks=1 --addons=registry
 	echo "sleeping before proceeding" && sleep 22
 	minikube start --profile "${MANAGEDCLUSTER1}" --network="${METRONET}" --insecure-registry="${metroNetIP}/24" --nodes=1 --extra-disks=1 --addons=registry

--- a/hack/metrodr-script.sh
+++ b/hack/metrodr-script.sh
@@ -7,7 +7,6 @@ export CEPHCLUSTER="${CEPHCLUSTER:-cephcluster}"
 export METRONET="${METRONET:-default}"
 export MANAGEDCLUSTER_ROOK_NAMESPACE="${MANAGEDCLUSTER_ROOK_NAMESPACE:-rook-ceph}"
 basedir="$(dirname "$(realpath "$0")")"
-scriptdir="$basedir/ramen-1"
 
 export PATH=${HOME}/.local/bin:${PATH}
 
@@ -74,16 +73,16 @@ function connect_external_storage_cluster() {
 	echo "======Deploying rook operator=======" && sleep 100
         kubectl --context "${KUBECLUSTER}" create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/operator.yaml
 	echo "======Deploying cluster=======" && sleep 100
-	kubectl --context "${KUBECLUSTER}" create -f "${scriptdir}/hack/dev-rook-cluster-external.yaml"
+	kubectl --context "${KUBECLUSTER}" create -f "${basedir}/dev-rook-cluster-external.yaml"
 	echo "======Deploying toolbox=======" && sleep 100
         kubectl --context "${KUBECLUSTER}" create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/toolbox.yaml
 	
         # exit 0
 	# echo "======Deploying pool=======" && sleep 100
-	# kubectl --context ${KUBECLUSTER} create -f "${scriptdir}/hack/dev-rook-rbdpool.yaml"
+	# kubectl --context ${KUBECLUSTER} create -f "${basedir}/dev-rook-rbdpool.yaml"
 	# echo "======Deploying rbd storageclass=======" && sleep 100
 
-        kubectl --context "${KUBECLUSTER}" create -f "${scriptdir}/hack/dev-rook-sc.yaml"
+        kubectl --context "${KUBECLUSTER}" create -f "${basedir}/dev-rook-sc.yaml"
         echo "======Patching default storageClass to rbd"
         kubectl --context "${KUBECLUSTER}" patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
         kubectl --context "${KUBECLUSTER}" patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
@@ -189,15 +188,15 @@ then
         kubectl --context "${CEPHCLUSTER}" create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/operator.yaml
 	echo "======Deploying cluster=======" && sleep 100
 	#kubectl --context ${CEPHCLUSTER} create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/cluster.yaml
-	kubectl --context "${CEPHCLUSTER}" create -f "${scriptdir}/hack/dev-rook-cluster.yaml"
+	kubectl --context "${CEPHCLUSTER}" create -f "${basedir}/dev-rook-cluster.yaml"
 	echo "======Deploying toolbox=======" && sleep 100
         kubectl --context "${CEPHCLUSTER}" create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/toolbox.yaml
 	echo "======Deploying pool=======" && sleep 100
-        kubectl --context "${CEPHCLUSTER}" create -f "${scriptdir}/hack/dev-rook-rbdpool.yaml"
+        kubectl --context "${CEPHCLUSTER}" create -f "${basedir}/dev-rook-rbdpool.yaml"
 	# echo "======Deploying filesystem=======" && sleep 100
  	# kubectl --context ${CEPHCLUSTER} create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/filesystem.yaml
 	echo "======Deploying rbd storageclass=======" && sleep 100
-        kubectl --context "${CEPHCLUSTER}" create -f "${scriptdir}/hack/dev-rook-sc.yaml"
+        kubectl --context "${CEPHCLUSTER}" create -f "${basedir}/dev-rook-sc.yaml"
 	# echo "======Deploying fs storageclass=======" && sleep 100
         # kubectl --context ${CEPHCLUSTER} create -f https://raw.githubusercontent.com/rook/rook/master/deploy/examples/csi/cephfs/storageclass.yaml
 

--- a/hack/metrodr-script.sh
+++ b/hack/metrodr-script.sh
@@ -126,10 +126,10 @@ fi
 
 if [[ $1 == "setup" ]]
 then
-        echo "hub cluster:" && echo "$HUBCLUSTER"
-        echo "mangedcluster1:" && echo "$MANAGEDCLUSTER1"	
-	echo "storage cluster:" && echo "$CEPHCLUSTER"
-	echo "network:" && echo "$METRONET"
+        echo "hub cluster: $HUBCLUSTER"
+        echo "mangedcluster1: $MANAGEDCLUSTER1"	
+	echo "storage cluster: $CEPHCLUSTER"
+	echo "network: $METRONET"
 	
 	metroNetIP=$(virsh net-dumpxml "${METRONET}" | grep "ip address" | cut -d"=" -f2 | cut -d" " -f1 | tr -d "'")
         minikube start --profile "${HUBCLUSTER}" --network="${METRONET}" --insecure-registry="${metroNetIP}/24" --nodes=1 --extra-disks=1 --addons=registry


### PR DESCRIPTION
some of the changes to the script: 
1. moving the script to hack dir and make use of `basedir` while correcting the path
2. use `METRONET` env variable directly instead of grepping when searching for `metroNetIP`
3. remove the line where `rook-cephfs` patching happens as this sc is not created
4. improve echo statements in the setup target

[Here is the LOG](https://privatebin.corp.redhat.com/?7b5fa1001ed42c48#7uyCYBPVk6L9jwrqCq6tizByhCzmNHsX8umygj7PjNGn)