### PR TITLE
VRG: CRD changes to VRG to support MetroDR

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -47,6 +47,27 @@ const (
 	UnknownState State = "Unknown"
 )
 
+type Mode string
+
+const (
+	// Only protect the ClusterData associated with
+	// storage resources such as PV/PVC etc. Used
+	// for MetroDR.
+	ClusterDataBackup Mode = "ClusterDataBackup"
+
+	// Protect the ClusterData of storage resources and
+	// sync the data from persistent volumes to the peer
+	// cluster. Mainly RegionalDR.
+	ClusterDataBackupAndReplication Mode = "ClusterDataBackupAndReplication"
+
+	// Protect the ClusterData of storage resources and
+	// fence off a peer cluster. Mainly used for MetroDR
+	ClusterDataBackupAndClusterFencing Mode = "ClusterDataBackupAndClusterFencing"
+
+	// UnknwonMode represents unknown mode
+	UnknownMode Mode = "Unknown"
+)
+
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // VolumeReplicationGroup (VRG) spec declares the desired schedule for data
@@ -87,6 +108,9 @@ type VolumeReplicationGroupSpec struct {
 	// List of unique S3 profiles in RamenConfig that should be used to store
 	// and forward PV related cluster state to peer DR clusters.
 	S3Profiles []string `json:"s3Profiles"`
+
+	// Indiciation to VRG about whether it is MetroDR or RegionalDR.
+	Mode Mode `json:"mode"`
 }
 
 type ProtectedPVC struct {

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -49,6 +49,9 @@ spec:
               from a secret resource.  - Manage the lifecycle of VR CR and S3 data
               according to CUD operations on    the PVC and the VRG CR."
             properties:
+              mode:
+                description: Indiciation to VRG about whether it is MetroDR or RegionalDR.
+                type: string
               pvcSelector:
                 description: Label selector to identify all the PVCs that are in this
                   group that needs to be replicated to the peer cluster.
@@ -160,6 +163,7 @@ spec:
                 pattern: ^\d+[mhd]$
                 type: string
             required:
+            - mode
             - pvcSelector
             - replicationState
             - s3Profiles


### PR DESCRIPTION
Adds modes to VRG Spec to indicate what it should do.
Currently (with the only DR capability being RegionalDR)
VRG backsup the the cluster data of storage related resources
such as PV/PVC and triggers a replication of data for those
PVs. For metroDR, there is a need for fencing operation. Hence,
depending upon the mode VRG can do one of the following three
operations

1) Backup cluster data only:
   Only backups the cluster data of PV/PVC.

2) Backup cluster data + replication
   Backs up the cluster data of PV/PVC and initiates a replication
   of the data within those PVs to a peer cluster.

3) Backup cluster data + fencing
   Backs up the cluster data of PV/PVC and fences off a peer cluster.

Corresponding controller changes. By default if no mode is given,
"Backup cluster data + replication" is assumed (regionalDR).

Signed-off-by: Raghavendra M <raghavendra@redhat.com>